### PR TITLE
BREAKING: Store event system overhaul

### DIFF
--- a/src/lib/core/createPersistentStore.test.ts
+++ b/src/lib/core/createPersistentStore.test.ts
@@ -6,7 +6,6 @@ describe("createPersistentStore", () => {
   const key = "test";
   const initialState = { count: 0 };
   const listener = vi.fn();
-  const listener2 = vi.fn();
   const initKey = `init_${key}`;
   const storeKey = `store_${key}`;
 
@@ -54,25 +53,6 @@ describe("createPersistentStore", () => {
     localStorage.setItem(storeKey, JSON.stringify({ count: 2 }));
     window.dispatchEvent(new Event("focus"));
     expect(store.get()).toEqual({ count: 2 });
-  });
-
-  it("should add and remove event listeners once", () => {
-    const store = createPersistentStore(key, initialState);
-    const addEventListenerSpy = vi.spyOn(window, "addEventListener");
-    const addStoreListenerSpy = vi.spyOn(store, "addEventListener");
-    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
-    const removeStoreListenerSpy = vi.spyOn(store, "removeEventListener");
-
-    const unsubscribe = store.subscribe(listener);
-    const unsubscribe2 = store.subscribe(listener2);
-    store.set({ count: 1 });
-    unsubscribe();
-    unsubscribe2();
-
-    expect(addEventListenerSpy).toHaveBeenCalledOnce();
-    expect(addStoreListenerSpy).toHaveBeenCalledOnce();
-    expect(removeEventListenerSpy).toHaveBeenCalledOnce();
-    expect(removeStoreListenerSpy).toHaveBeenCalledOnce();
   });
 
   it("should use custom serializer", () => {

--- a/src/lib/core/createPersistentStore.ts
+++ b/src/lib/core/createPersistentStore.ts
@@ -111,18 +111,18 @@ export const createPersistentStore = <
   };
 
   const store = createStore(initialState, defineActions, {
-    onAttach: (state, set) => {
+    onAttach: (...args) => {
       updateState();
       window.addEventListener("focus", updateState);
-      onAttach?.(state, set);
+      onAttach?.(...args);
     },
-    onDetach: (state, set) => {
+    onDetach: (...args) => {
       window.removeEventListener("focus", updateState);
-      onDetach?.(state, set);
+      onDetach?.(...args);
     },
-    onStateChange: (state, set) => {
+    onStateChange: (state, ...args) => {
       updateSnapshot(state);
-      onStateChange?.(state, set);
+      onStateChange?.(state, ...args);
     },
     ...options,
   });

--- a/src/lib/core/createPersistentStore.ts
+++ b/src/lib/core/createPersistentStore.ts
@@ -69,13 +69,14 @@ export const createPersistentStore = <
   {
     storage: _storage = "local",
     serializer = JSON,
+    onAttach,
+    onDetach,
+    onStateChange,
     ...options
   }: PersistentStoreOptions<TState> = {},
 ): Store<TState, TActions> => {
-  const store = createStore(initialState, defineActions, options);
-
   if (typeof window === "undefined") {
-    return store;
+    return createStore(initialState, defineActions, options);
   }
 
   const storage = _storage === "local" ? localStorage : sessionStorage;
@@ -109,15 +110,21 @@ export const createPersistentStore = <
     }
   };
 
-  store.addEventListener("attach", () => {
-    updateState();
-    store.addEventListener("change", updateSnapshot);
-    window.addEventListener("focus", updateState);
-  });
-
-  store.addEventListener("detach", () => {
-    store.removeEventListener("change", updateSnapshot);
-    window.removeEventListener("focus", updateState);
+  const store = createStore(initialState, defineActions, {
+    onAttach: (state, set) => {
+      updateState();
+      window.addEventListener("focus", updateState);
+      onAttach?.(state, set);
+    },
+    onDetach: (state, set) => {
+      window.removeEventListener("focus", updateState);
+      onDetach?.(state, set);
+    },
+    onStateChange: (state, set) => {
+      updateSnapshot(state);
+      onStateChange?.(state, set);
+    },
+    ...options,
   });
 
   return store;

--- a/src/lib/core/createStore.ts
+++ b/src/lib/core/createStore.ts
@@ -5,27 +5,17 @@ export type Store<TState extends object, TActions extends object> = {
   get: () => TState;
   /** Sets the state of the store. */
   set: (stateModifier: StateModifier<TState>) => TState;
-  /** Subscribes to changes in the state of the store. Returns an unsubscribe function. */
-  subscribe: (listener: Listener) => Listener;
   /** Actions that can modify the state of the store. */
   actions: TActions;
-  /** Adds an event listener to the store. */
-  addEventListener: (
-    event: StoreEvent,
-    listener: StoreListener<TState>,
-  ) => void;
-  /** Removes an event listener from the store. */
-  removeEventListener: (
-    event: StoreEvent,
-    listener: StoreListener<TState>,
-  ) => void;
+  /** Subscribes to changes in the state of the store. Returns an unsubscribe function. */
+  subscribe: (listener: Listener) => Listener;
 };
 
 type Listener = () => void;
 
 export type StoreEvent = "attach" | "detach" | "change" | "load";
 
-export type StoreListener<TState extends object> = (
+export type StoreEventHandler<TState extends object> = (
   state: TState,
   set: SetState<TState>,
 ) => void;
@@ -47,13 +37,13 @@ export type DefineActions<TState extends object, TActions> = (
 
 export type StoreOptions<TState extends object> = {
   /** Invoked when the store is created. */
-  onLoad?: StoreListener<TState>;
+  onLoad?: StoreEventHandler<TState>;
   /** Invoked when the store is subscribed to. */
-  onAttach?: StoreListener<TState>;
+  onAttach?: StoreEventHandler<TState>;
   /** Invoked when the store is unsubscribed from. */
-  onDetach?: StoreListener<TState>;
+  onDetach?: StoreEventHandler<TState>;
   /** Invoked whenever the state changes. */
-  onStateChange?: StoreListener<TState>;
+  onStateChange?: StoreEventHandler<TState>;
   /** Whether to reset the state to the initial state when the store is detached. */
   resetOnDetach?: boolean;
 };
@@ -96,33 +86,6 @@ export const createStore = <
   let state = initialState;
   const listeners = new Set<Listener>();
 
-  const eventListeners: Record<StoreEvent, Set<StoreListener<TState>>> = {
-    load: new Set(onLoad ? [onLoad] : []),
-    attach: new Set(onAttach ? [onAttach] : []),
-    detach: new Set(onDetach ? [onDetach] : []),
-    change: new Set(onStateChange ? [onStateChange] : []),
-  };
-
-  const addEventListener = (
-    event: StoreEvent,
-    listener: StoreListener<TState>,
-  ) => {
-    eventListeners[event].add(listener);
-  };
-
-  const removeEventListener = (
-    event: StoreEvent,
-    listener: StoreListener<TState>,
-  ) => {
-    eventListeners[event].delete(listener);
-  };
-
-  const dispatchEvent = (event: StoreEvent, silent = false) => {
-    eventListeners[event].forEach((listener) =>
-      listener(state, silent ? setSilently : set),
-    );
-  };
-
   const get = () => state;
 
   const setSilently = (stateModifier: StateModifier<TState>) => {
@@ -131,7 +94,7 @@ export const createStore = <
   };
 
   const dispatch = () => {
-    dispatchEvent("change", true);
+    onStateChange?.(state, setSilently);
     listeners.forEach((listener) => listener());
   };
 
@@ -143,7 +106,7 @@ export const createStore = <
 
   const subscribe = (listener: Listener) => {
     if (listeners.size === 0) {
-      dispatchEvent("attach");
+      onAttach?.(state, set);
     }
 
     listeners.add(listener);
@@ -152,7 +115,7 @@ export const createStore = <
       listeners.delete(listener);
 
       if (listeners.size === 0) {
-        dispatchEvent("detach");
+        onDetach?.(state, set);
 
         if (resetOnDetach) {
           state = initialState;
@@ -164,14 +127,12 @@ export const createStore = <
 
   const actions = defineActions ? defineActions(set, get) : ({} as TActions);
 
-  dispatchEvent("load");
+  onLoad?.(state, set);
 
   return {
     get,
     set,
     subscribe,
     actions,
-    addEventListener,
-    removeEventListener,
   };
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "declaration": true,
-    "strict": true
+    "strict": true,
+    "noEmit": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
- Store event listeners can no longer be added or removed from the store object after initialization.
- Regular listeners (those added via the subscribe function) are now stored in a set rather than an array.